### PR TITLE
fix an Uncaught exception issue when the PNG file is corrupted

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,8 +11,8 @@ if(method === 'encode') {
   process.stdin
     .pipe(ndjson.parse())
     .pipe(through.obj(function (chunk, enc, cb) {
-      chunk.data = new Buffer(chunk.data, 'base64')
-      chunk.crc = new Buffer(chunk.crc, 'base64')
+      chunk.data = new Buffer.from(chunk.data, 'base64')
+      chunk.crc = new Buffer.from(chunk.crc, 'base64')
       this.push(chunk)
       cb()
     }))

--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-var decoder = require('./').decode()
-var encoder = require('./').encode()
-var through = require('through2')
-var ndjson = require('ndjson')
+const decoder = require('./').decode()
+const encoder = require('./').encode()
+const through = require('through2')
+const ndjson = require('ndjson')
 
-var method = process.argv[2]
+const method = process.argv[2]
 
 if(method === 'encode') {
   process.stdin
@@ -23,7 +23,7 @@ if(method === 'encode') {
     process.stdin
       .pipe(decoder)
       .on('error', err => {
-        console.error(err)
+        console.error(`decode error:`, err)
         process.exit(1)
       })
       .pipe(through.obj(function (chunk, enc, cb) {
@@ -35,7 +35,7 @@ if(method === 'encode') {
       .pipe(ndjson.stringify())
       .pipe(process.stdout)
   } catch (e) {
-    console.error(e)
+    console.error(`Catch error:`, e)
   }
 } else {
   console.error('Usage: png-chunk [encode/decode]')

--- a/cli.js
+++ b/cli.js
@@ -19,16 +19,24 @@ if(method === 'encode') {
     .pipe(encoder)
     .pipe(process.stdout)
 } else if(method === 'decode'){
-  process.stdin
-    .pipe(decoder)
-    .pipe(through.obj(function (chunk, enc, cb) {
-      chunk.data = chunk.data.toString('base64')
-      chunk.crc = chunk.crc.toString('base64')
-      this.push(chunk)
-      cb()
-    }))
-    .pipe(ndjson.stringify())
-    .pipe(process.stdout)
+  try {
+    process.stdin
+      .pipe(decoder)
+      .on('error', err => {
+        console.error(err)
+        process.exit(1)
+      })
+      .pipe(through.obj(function (chunk, enc, cb) {
+        chunk.data = chunk.data.toString('base64')
+        chunk.crc = chunk.crc.toString('base64')
+        this.push(chunk)
+        cb()
+      }))
+      .pipe(ndjson.stringify())
+      .pipe(process.stdout)
+  } catch (e) {
+    console.error(e)
+  }
 } else {
   console.error('Usage: png-chunk [encode/decode]')
 }

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -1,8 +1,8 @@
-var Transform = require('stream').Transform
-var inherits = require('inherits')
-var equal = require('buffer-equal')
+const Transform = require('stream').Transform
+const inherits = require('inherits')
+const equal = require('buffer-equal')
 
-var PNGsignature = new Buffer([137, 80, 78, 71, 13, 10, 26, 10])
+const PNGsignature = new Buffer([137, 80, 78, 71, 13, 10, 26, 10])
 
 function Decoder(opts) {
   if(!(this instanceof Decoder)) return new Decoder(opts)
@@ -31,11 +31,22 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
       return cb()
     }
   } 
-   
+  
+  this.afterIEND = false
+
   while(this.nread > 0) {
+    if (this.afterIEND) {
+      // after IEND chunk, it should not have any other chunks - security concern
+      // It should not parse them. This could possiblly be a corrupted PNG file.
+      return cb(new Error('After IEND chunk, should not have other chunks.'))
+    }
     this.current = this.current || {}
     if (this.buffer.length < 4) {
       // invalid chunk length
+      // the Node.js Buffer class does not support negative length
+      // and if the length is negative, it will throw an error. However, in the stream pipe operation,
+      // the readInt32BE method will not emit an error, that causes the .on('error', cb) will not be called.
+      // It always causes the uncaught exception.
       return cb(new Error(`Invalid PNG buffer length: ${this.buffer.length}`));
     }
     
@@ -50,7 +61,7 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
       this.buffer = this.buffer.slice(4)
     }
     if(this.nread >= 8 && !('type' in this.current)) {
-      var type = this.buffer.slice(0, 4)
+      const type = this.buffer.slice(0, 4)
       this.current.type = type.toString('ascii')
       this.buffer = this.buffer.slice(4)
     }
@@ -67,10 +78,13 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
     } else {
       break
     }
-    // if (this.current.type === 'IEND') {
-    //   this.emit('end')
-    //   break
-    // }
+    // It supposes that the last chunk is IEND. The corrupted PNG file may not have IEND chunk.
+    // or after the IEND chunk, there may be other chunks.
+    if (this.current.type === 'IEND') {
+      this.afterIEND = true
+      // this.emit('end')
+      // break
+    }
     this.current = {}
   }
   cb()

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -2,13 +2,13 @@ const Transform = require('stream').Transform
 const inherits = require('inherits')
 const equal = require('buffer-equal')
 
-const PNGsignature = new Buffer([137, 80, 78, 71, 13, 10, 26, 10])
+const PNGsignature = new Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
 
 function Decoder(opts) {
   if(!(this instanceof Decoder)) return new Decoder(opts)
   this.nread = 0
   this.signature = null
-  this.buffer = new Buffer(0)
+  this.buffer = new Buffer.alloc(0)
   Transform.call(this, {objectMode: true})
 }
 inherits(Decoder, Transform)
@@ -41,14 +41,6 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
       return cb(new Error('After IEND chunk, should not have other chunks.'))
     }
     this.current = this.current || {}
-    if (this.buffer.length < 4) {
-      // invalid chunk length
-      // the Node.js Buffer class does not support negative length
-      // and if the length is negative, it will throw an error. However, in the stream pipe operation,
-      // the readInt32BE method will not emit an error, that causes the .on('error', cb) will not be called.
-      // It always causes the uncaught exception.
-      return cb(new Error(`Invalid PNG buffer length: ${this.buffer.length}`));
-    }
     
     if(this.nread >= 4 && !('length' in this.current)) {
       this.current.length =  this.buffer.readInt32BE(0)

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -64,13 +64,14 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
       this.buffer = this.buffer.slice(4)
       this.nread = this.nread - 12 - this.current.length
       this.push(this.current)
-      this.current = false
     } else {
-      return cb()
+      break
     }
-    if (this.current.type === 'IEND') {
-      return cb();
-    }
+    // if (this.current.type === 'IEND') {
+    //   this.emit('end')
+    //   break
+    // }
+    this.current = {}
   }
   cb()
 }

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -34,9 +34,19 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
    
   while(this.nread > 0) {
     this.current = this.current || {}
+    if (this.buffer.length < 4) {
+      // invalid chunk length
+      return cb(new Error(`Invalid PNG buffer length: ${this.buffer.length}`));
+    }
     
     if(this.nread >= 4 && !('length' in this.current)) {
       this.current.length =  this.buffer.readInt32BE(0)
+      if (this.current.length < 0) {
+        // it is possible to have the negative length when the PNG file is corrupted
+        // or when the PNG file is not a valid PNG file
+        // in this case, we should stop the stream and return an error
+        return cb(new Error(`Invalid PNG chunk length: ${this.current.length}`));
+      }
       this.buffer = this.buffer.slice(4)
     }
     if(this.nread >= 8 && !('type' in this.current)) {
@@ -57,6 +67,9 @@ Decoder.prototype._transform = function _transform(chunk, enc, cb) {
       this.current = false
     } else {
       return cb()
+    }
+    if (this.current.type === 'IEND') {
+      return cb();
     }
   }
   cb()

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,8 +1,8 @@
-var Transform = require('stream').Transform
-var inherits = require('inherits')
-var crc32 = require('buffer-crc32')
+const Transform = require('stream').Transform
+const inherits = require('inherits')
+const crc32 = require('buffer-crc32')
 
-var PNGsignature = new Buffer([137, 80, 78, 71, 13, 10, 26, 10])
+const PNGsignature = new Buffer([137, 80, 78, 71, 13, 10, 26, 10])
 
 function Encoder(opts) {
   if(!(this instanceof Encoder)) return new Encoder(opts)
@@ -17,11 +17,19 @@ Encoder.prototype._transform = function _transform(chunk, enc, cb) {
     this.signature = true
   }
   
-  var length = new Buffer(4)
-  length.writeUInt32BE(chunk.length || chunk.data.length, 0)
+  const length = new Buffer(4)
+  // http://www.libpng.org/pub/png/book/chapter08.html#png.ch08.div.1
+  // The length field is a 4-byte unsigned integer that indicates the
+  // 4-byte length (in ``big-endian'' format, as with all integer values in PNG streams), a 4-byte chunk type, 
+  // between 0 and 2,147,483,647 bytes of chunk data
+  if (chunk.length > 2147483647 || chunk.data.length > 2147483647 
+    || chunk.length < 0 || chunk.data.length < 0) {
+    return cb(new Error('Chunk length exceeds maximum value'))
+  }
+  length.writeInt32BE(chunk.length || chunk.data.length, 0)
   this.push(length)
   
-  var type = new Buffer(chunk.type)
+  const type = new Buffer(chunk.type)
   this.push(type)
   
   this.push(chunk.data)

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -2,7 +2,7 @@ const Transform = require('stream').Transform
 const inherits = require('inherits')
 const crc32 = require('buffer-crc32')
 
-const PNGsignature = new Buffer([137, 80, 78, 71, 13, 10, 26, 10])
+const PNGsignature = new Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
 
 function Encoder(opts) {
   if(!(this instanceof Encoder)) return new Encoder(opts)
@@ -17,7 +17,7 @@ Encoder.prototype._transform = function _transform(chunk, enc, cb) {
     this.signature = true
   }
   
-  const length = new Buffer(4)
+  const length = new Buffer.alloc(4)
   // http://www.libpng.org/pub/png/book/chapter08.html#png.ch08.div.1
   // The length field is a 4-byte unsigned integer that indicates the
   // 4-byte length (in ``big-endian'' format, as with all integer values in PNG streams), a 4-byte chunk type, 
@@ -29,7 +29,7 @@ Encoder.prototype._transform = function _transform(chunk, enc, cb) {
   length.writeInt32BE(chunk.length || chunk.data.length, 0)
   this.push(length)
   
-  const type = new Buffer(chunk.type)
+  const type = new Buffer.from(chunk.type)
   this.push(type)
   
   this.push(chunk.data)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "png-chunk-stream",
-  "version": "1.1.0",
+  "name": "png-chunk-streamer",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "png-chunk-stream",
-      "version": "1.1.0",
+      "name": "png-chunk-streamer",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,172 @@
+{
+  "name": "png-chunk-stream",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "png-chunk-stream",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.3",
+        "buffer-equal": "0.0.1",
+        "inherits": "^2.0.1",
+        "ndjson": "^1.2.2"
+      },
+      "bin": {
+        "png-chunk": "cli.js"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha512-hUPLuaziboGjNF7wHngkgVc0FOclR8dDk/HfEvTtDr/iUrqBWiRcRSTK3/nLOqKH33th714BrMmTPtObI9gZxQ==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/split2": {
+      "version": "2.2.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dependencies": {
+        "through2": "^2.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,32 +9,35 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "^0.2.3",
-        "buffer-equal": "0.0.1",
-        "inherits": "^2.0.1",
-        "ndjson": "^1.2.2"
+        "buffer-crc32": "^1.0.0",
+        "buffer-equal": "^1.0.1",
+        "inherits": "^2.0.4",
+        "ndjson": "^2.0.0"
       },
       "bin": {
         "png-chunk": "cli.js"
       },
       "devDependencies": {
-        "concat-stream": "^1.4.6"
+        "concat-stream": "^2.0.0"
       }
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "version": "1.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+      "version": "1.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/buffer-equal/-/buffer-equal-1.0.1.tgz",
+      "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/buffer-from": {
@@ -44,34 +47,24 @@
       "dev": true
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "dev": true,
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -87,66 +80,77 @@
       }
     },
     "node_modules/ndjson": {
-      "version": "1.5.0",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/ndjson/-/ndjson-1.5.0.tgz",
-      "integrity": "sha512-hUPLuaziboGjNF7wHngkgVc0FOclR8dDk/HfEvTtDr/iUrqBWiRcRSTK3/nLOqKH33th714BrMmTPtObI9gZxQ==",
+      "version": "2.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/ndjson/-/ndjson-2.0.0.tgz",
+      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^2.1.0",
-        "through2": "^2.0.3"
+        "minimist": "^1.2.5",
+        "readable-stream": "^3.6.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
       },
       "bin": {
         "ndjson": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "version": "3.6.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/split2": {
-      "version": "2.2.0",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "version": "3.2.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dependencies": {
-        "through2": "^2.0.2"
+        "readable-stream": "^3.0.0"
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "version": "4.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
       "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "3"
       }
     },
     "node_modules/typedarray": {
@@ -159,14 +163,6 @@
       "version": "1.0.2",
       "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/lsc-npm-virtual/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "png-chunk-stream",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Decode and Encode PNG chunks",
   "main": "index.js",
   "bin": {
     "png-chunk": "./cli.js"
   },
   "dependencies": {
-    "buffer-crc32": "^0.2.3",
-    "buffer-equal": "0.0.1",
-    "inherits": "^2.0.1",
-    "ndjson": "^1.2.2"
+    "buffer-crc32": "^1.0.0",
+    "buffer-equal": "^1.0.1",
+    "inherits": "^2.0.4",
+    "ndjson": "^2.0.0"
   },
   "devDependencies": {
-    "concat-stream": "^1.4.6"
+    "concat-stream": "^2.0.0"
   },
   "scripts": {
     "test": "node test.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "png-chunk-stream",
-  "version": "1.1.1",
-  "description": "Decode and Encode PNG chunks",
+  "name": "png-chunk-streamer",
+  "version": "1.1.2",
+  "description": "Decode and Encode PNG chunks - originally from png-chunk-stream",
   "main": "index.js",
   "bin": {
     "png-chunk": "./cli.js"
@@ -20,16 +20,24 @@
   },
   "keywords": [
     "png",
-    "chunk"
+    "chunk",
+    "stream",
+    "decode-encode"
   ],
   "author": "Finn Pauls",
+  "maintainers": [
+    {
+      "name": "SteveGY",
+      "url": "https://github.com/stevegy/png-chunk-stream/"
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/finnp/png-chunk-stream.git"
+    "url": "https://github.com/stevegy/png-chunk-stream.git"
   },
   "bugs": {
-    "url": "https://github.com/finnp/png-chunk-stream/issues"
+    "url": "https://github.com/stevegy/png-chunk-stream/issues"
   },
-  "homepage": "https://github.com/finnp/png-chunk-stream"
+  "homepage": "https://github.com/stevegy/png-chunk-stream"
 }

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,14 @@
-# png-chunk-stream
-Windows | Mac/Linux
-------- | ---------
-[![Windows Build status](http://img.shields.io/appveyor/ci/finnp/png-chunk-stream.svg)](https://ci.appveyor.com/project/finnp/png-chunk-stream/branch/master) | [![Build Status](https://travis-ci.org/finnp/png-chunk-stream.svg?branch=master)](https://travis-ci.org/finnp/png-chunk-stream)
+# png-chunk-streamer - originally png-chunk-stream by finnp
+
+This is a bug fix for the png-chunk-stream. It seems the origin lib is not maintained.
+
+This is a dependent lib for the png-itxt.
+
+The original lib is at https://github.com/finnp/png-chunk-stream
+
+Under this line is the original README.md.
+
+-------
 
 A small simple helper for working with PNG files, inspired by [chunky-stream](https://www.npmjs.org/package/chunky-rice). 
 It is supposed to be lightweight and usable with browserify.


### PR DESCRIPTION
The `buffer.readInt32BE(0)` has an strange behavior when it tries to read out of the buffer range. It throws an exception `RangeError [ERR_BUFFER_OUT_OF_BOUNDS]`. But when the decoder is working in a stream pipe, the exception is not able to be caught by `try-catch` or `pipe.on('error', handler)`.
It could happen when the input PNG file is corrupted including invalid chunk size. To properly handle the exception helps a service app without crashing.
The related `png-itxt` may need to update the dependency to this new version 1.1.1.
Thank you.